### PR TITLE
Fix syntax error in render-start.sh

### DIFF
--- a/scripts/render-start.sh
+++ b/scripts/render-start.sh
@@ -40,7 +40,7 @@ fi
 LOG_FILE="/tmp/puppeteer-install-$(date +%s).log"
 log "Installing Chrome via Puppeteer CLI (logs: $LOG_FILE)"
 set +e
-{"${TIMEOUT_PREFIX[@]}" npx puppeteer browsers install chrome --verbose; } 2>&1 | tee -a "$LOG_FILE"
+"${TIMEOUT_PREFIX[@]}" npx puppeteer browsers install chrome --verbose 2>&1 | tee -a "$LOG_FILE"
 RC=${PIPESTATUS[0]:-0}
 set -e
 
@@ -48,7 +48,7 @@ if [[ $RC -ne 0 ]]; then
   log "First attempt failed (rc=$RC). Retrying with dl.google.com host"
   export PUPPETEER_DOWNLOAD_HOST="https://dl.google.com"
   set +e
-  {"${TIMEOUT_PREFIX[@]}" npx puppeteer browsers install chrome --verbose; } 2>&1 | tee -a "$LOG_FILE"
+  "${TIMEOUT_PREFIX[@]}" npx puppeteer browsers install chrome --verbose 2>&1 | tee -a "$LOG_FILE"
   RC=${PIPESTATUS[0]:-0}
   set -e
 fi


### PR DESCRIPTION
Remove incorrect curly braces from `puppeteer browsers install` commands in `scripts/render-start.sh` to fix a shell syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-457c2c59-5d7b-4849-a9e3-9529a2cd7ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-457c2c59-5d7b-4849-a9e3-9529a2cd7ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

