### PR TITLE
Secure sandbox rendering from html string

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ if (!process.env.PUPPETEER_EXECUTABLE_PATH) {
   }
 }
 const TelegramBot = require('node-telegram-bot-api');
-const express = require('express');
 const Database = require('./database/db');
 const CommandHandler = require('./handlers/commandHandler');
 const MessageHandler = require('./handlers/messageHandler');
@@ -55,28 +54,6 @@ if (!token) {
 } else {
   bot = new TelegramBot(token, { polling: true });
 }
-
-// ========================================
-// Express Server (for Render.com health check)
-// ========================================
-const app = express();
-const PORT = process.env.PORT || 3000;
-
-app.get('/', (req, res) => {
-  res.send('🤖 Markdown Trainer Bot is running!');
-});
-
-app.get('/health', (req, res) => {
-  res.json({ 
-    status: 'healthy',
-    uptime: process.uptime(),
-    timestamp: new Date().toISOString()
-  });
-});
-
-app.listen(PORT, () => {
-  console.log(`✅ Server is running on port ${PORT}`);
-});
 
 // ========================================
 // Database Initialization

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,5 @@
 services:
-  - type: web
+  - type: worker
     name: markdown-trainer-bot
     env: node
     plan: free
@@ -24,4 +24,3 @@ services:
         value: 600000
       - key: TELEGRAM_BOT_TOKEN
         sync: false
-    healthCheckPath: /health


### PR DESCRIPTION
Configure bot as a Render worker and remove Express server to enable background execution without open ports.

The bot's Puppeteer rendering already uses `page.setContent` locally, eliminating the need for a web service. This change prevents Render from attempting to scan for open ports, allowing the bot to run purely as a background worker.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ce99b7c-9ef6-4c7b-b45d-9a6396878b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ce99b7c-9ef6-4c7b-b45d-9a6396878b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

