### PR TITLE
Add Markdown Guide Button in Telegram Bot

### DIFF
--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -80,6 +80,7 @@ class CommandHandler {
       `/themes - בחר ערכת נושא לארגז החול\n` +
       `/templates - תבניות Markdown מוכנות לשימוש\n` +
       `/cheatsheet - הצג מדריך מהיר\n` +
+      `/markdown_guide - מדריך Markdown לטלגרם\n` +
       `/exit - צא ממצב מעבדה\n\n` +
       `💡 *טיפים:*\n` +
       `• השתמש באימון ממוקד (/train) לתרגל נושאים ספציפיים\n` +
@@ -384,6 +385,155 @@ class CommandHandler {
           ]
         }
       }
+    );
+  }
+
+  // ========================================
+  // /markdown_guide - Show Telegram Markdown formatting guide
+  // ========================================
+  async handleMarkdownGuide(msg) {
+    const chatId = msg.chat.id;
+    const userId = msg.from.id;
+
+    this.db.updateLastActive(userId);
+
+    // Part 1: Introduction
+    await this.safeSendMarkdown(chatId,
+      `📖 *מדריך Markdown לטלגרם*\n\n` +
+      `טלגרם תומך ב-Markdown כדי לאפשר לך לכתוב הודעות מעוצבות.\n` +
+      `המדריך הזה יראה לך איך להשתמש ב-MarkdownV2 (הגרסה המומלצת).\n\n` +
+      `👇 המדריך מחולק למספר חלקים:`
+    );
+
+    await this.sleep(1000);
+
+    // Part 2: Basic Formatting
+    await this.safeSendMarkdown(chatId,
+      `*📝 חלק 1: עיצוב בסיסי*\n\n` +
+      `*מודגש (Bold):*\n` +
+      `\`*טקסט מודגש*\`\n` +
+      `תוצאה: *טקסט מודגש*\n\n` +
+      `*נטוי (Italic):*\n` +
+      `\`_טקסט נטוי_\`\n` +
+      `תוצאה: _טקסט נטוי_\n\n` +
+      `*קו תחתון (Underline):*\n` +
+      `\`__טקסט עם קו תחתון__\`\n` +
+      `תוצאה: __טקסט עם קו תחתון__\n\n` +
+      `*קו חוצה (Strikethrough):*\n` +
+      `\`~טקסט עם קו חוצה~\`\n` +
+      `תוצאה: ~טקסט עם קו חוצה~`
+    );
+
+    await this.sleep(1500);
+
+    // Part 3: Code formatting
+    await this.safeSendMarkdown(chatId,
+      `*💻 חלק 2: עיצוב קוד*\n\n` +
+      `*קוד בשורה (Inline code):*\n` +
+      `השתמש ב-backticks:\n` +
+      `\\\`const x = 5;\\\`\n\n` +
+      `*בלוק קוד (Code block):*\n` +
+      `השתמש ב-3 backticks:\n` +
+      `\\\`\\\`\\\`javascript\n` +
+      `function hello() {\n` +
+      `  console.log("שלום!");\n` +
+      `}\n` +
+      `\\\`\\\`\\\`\n\n` +
+      `💡 ניתן להוסיף שם שפה (javascript, python, וכו') לתמיכה ב-syntax highlighting`
+    );
+
+    await this.sleep(1500);
+
+    // Part 4: Links
+    await this.safeSendMarkdown(chatId,
+      `*🔗 חלק 3: קישורים*\n\n` +
+      `*קישור רגיל:*\n` +
+      `\`[טקסט הקישור](https://example.com)\`\n\n` +
+      `*דוגמה:*\n` +
+      `[לחץ כאן](https://google.com)\n\n` +
+      `💡 טלגרם מזהה אוטומטית @mentions ו-#hashtags`
+    );
+
+    await this.sleep(1500);
+
+    // Part 5: CRITICAL - Escaping rules
+    await this.safeSendMarkdown(chatId,
+      `*⚠️ חלק 4: תווים מיוחדים (חשוב מאוד!)*\n\n` +
+      `ב-MarkdownV2, התווים הבאים *חייבים* להיות עם backslash לפניהם:\n\n` +
+      `\`_ * [ ] ( ) ~ \\\` > # + - = | { } . !\`\n\n` +
+      `*דוגמאות:*\n` +
+      `• \`\\\\*לא מודגש\\\\*\` → \\*לא מודגש\\*\n` +
+      `• \`נקודה\\\\.\` → נקודה.\n` +
+      `• \`סוגריים \\\\(טקסט\\\\)\` → סוגריים (טקסט)\n\n` +
+      `❗ זה הסיבה השכיחה ביותר לשגיאות parsing\\!`
+    );
+
+    await this.sleep(1500);
+
+    // Part 6: Bot implementation
+    await this.safeSendMarkdown(chatId,
+      `*🤖 חלק 5: שימוש בבוטים*\n\n` +
+      `*Python (python-telegram-bot):*\n` +
+      `\`\`\`python\n` +
+      `from telegram.constants import ParseMode\n\n` +
+      `await context.bot.send_message(\n` +
+      `    chat_id=chat_id,\n` +
+      `    text="*טקסט מודגש*",\n` +
+      `    parse_mode=ParseMode.MARKDOWN_V2\n` +
+      `)\n` +
+      `\`\`\`\n\n` +
+      `*Node.js (node-telegram-bot-api):*\n` +
+      `\`\`\`javascript\n` +
+      `bot.sendMessage(chatId, '*טקסט מודגש*', {\n` +
+      `  parse_mode: 'MarkdownV2'\n` +
+      `});\n` +
+      `\`\`\``
+    );
+
+    await this.sleep(1500);
+
+    // Part 7: Limitations
+    await this.safeSendMarkdown(chatId,
+      `*🚫 חלק 6: מגבלות טלגרם*\n\n` +
+      `טלגרם *לא תומך* בפיצ'רים הבאים:\n\n` +
+      `❌ כותרות (Headers)\n` +
+      `❌ טבלאות (Tables)\n` +
+      `❌ רשימות ממוספרות\n` +
+      `❌ ציטוטים (Blockquotes)\n` +
+      `❌ תמונות מוטמעות\n\n` +
+      `💡 השתמש ב-HTML parsing mode אם אתה צריך יותר אופציות עיצוב`
+    );
+
+    await this.sleep(1500);
+
+    // Part 8: Common issues and tips
+    await this.safeSendMarkdown(chatId,
+      `*💡 חלק 7: טיפים ופתרון בעיות*\n\n` +
+      `*שגיאות נפוצות:*\n\n` +
+      `1️⃣ "Can't parse entities"\n` +
+      `→ בדוק שעשית escape לכל התווים המיוחדים\n\n` +
+      `2️⃣ קישור לא עובד\n` +
+      `→ ודא שה-URL מלא (כולל https://)\n\n` +
+      `3️⃣ בלוק קוד לא מוצג נכון\n` +
+      `→ בדוק שיש בדיוק 3 backticks בהתחלה ובסוף\n\n` +
+      `4️⃣ טקסט לא מתעצב\n` +
+      `→ ודא שאין רווחים בתוך תגי העיצוב\n\n` +
+      `*טיפ:* השתמש במעבדה שלנו (/sandbox) לתרגל Markdown רגיל!`
+    );
+
+    await this.sleep(1000);
+
+    // Final message with quick reference
+    await this.safeSendMarkdown(chatId,
+      `📋 *סיכום מהיר:*\n\n` +
+      `\`*מודגש*\` | \`_נטוי_\` | \`__קו תחתון__\`\n` +
+      `\`~קו חוצה~\` | \`\\\`קוד\\\`\` | \`[קישור](url)\`\n\n` +
+      `❗ זכור: תווים מיוחדים דורשים backslash!\n\n` +
+      `📚 רוצה לתרגל? נסה:\n` +
+      `• /sandbox - תרגול Markdown רגיל\n` +
+      `• /cheatsheet - מדריך מהיר\n` +
+      `• /templates - תבניות מוכנות\n\n` +
+      `מקור: @moominAmir`
     );
   }
 
@@ -703,7 +853,7 @@ class CommandHandler {
         [{ text: '📚 שיעור הבא' }, { text: '🧪 מעבדה' }],
         [{ text: '🎯 אימון' }, { text: '📊 התקדמות' }],
         [{ text: '📋 מדריך מהיר' }, { text: '📚 תבניות' }],
-        [{ text: '❓ עזרה' }]
+        [{ text: '📖 מדריך טלגרם' }, { text: '❓ עזרה' }]
       ],
       resize_keyboard: true,
       one_time_keyboard: false

--- a/handlers/messageHandler.js
+++ b/handlers/messageHandler.js
@@ -45,6 +45,7 @@ class MessageHandler {
       '📊 התקדמות',
       '📋 מדריך מהיר',
       '📚 תבניות',
+      '📖 מדריך טלגרם',
       '❓ עזרה'
     ];
 
@@ -133,6 +134,9 @@ class MessageHandler {
       return;
     } else if (text === '📚 תבניות') {
       await cmdHandler.handleTemplates(msg);
+      return;
+    } else if (text === '📖 מדריך טלגרם') {
+      await cmdHandler.handleMarkdownGuide(msg);
       return;
     } else if (text === '❓ עזרה') {
       await cmdHandler.handleHelp(msg);

--- a/index.js
+++ b/index.js
@@ -151,6 +151,13 @@ if (bot && commandHandler && messageHandler) {
     }
   });
 
+  // Handle /markdown_guide command (Telegram Markdown guide)
+  bot.onText(/\/markdown_guide/, async (msg) => {
+    if (await maintenanceMiddleware(msg, () => true)) {
+      commandHandler.handleMarkdownGuide(msg);
+    }
+  });
+
   // Handle /templates command
   bot.onText(/\/templates/, async (msg) => {
     if (await maintenanceMiddleware(msg, () => true)) {


### PR DESCRIPTION
הוספת פקודה חדשה שמציגה מדריך מקיף לשימוש ב-Markdown בטלגרם (MarkdownV2):
- עיצוב בסיסי (מודגש, נטוי, קו תחתון, קו חוצה)
- עיצוב קוד (inline ובלוקים)
- קישורים
- תווים מיוחדים ו-escaping
- דוגמאות לשימוש בבוטים (Python ו-Node.js)
- מגבלות טלגרם
- טיפים ופתרון בעיות שכיחות

השינויים כוללים:
- פונקציה חדשה handleMarkdownGuide ב-commandHandler.js
- רישום הפקודה /markdown_guide ב-index.js
- כפתור חדש "📖 מדריך טלגרם" במקלדת הראשית
- טיפול בלחיצה על הכפתור ב-messageHandler.js
- הוספת הפקודה למסך העזרה /help

מקור המדריך: https://gist.github.com/amirbiron/2800dafb3a114353f8eba194ba8b77ec

🤖 Generated with [Claude Code](https://claude.com/claude-code)