### PR TITLE
Fix markdown rendering and training modes

### DIFF
--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -1131,12 +1131,26 @@ await update.message.reply_text(msg, parse_mode="MarkdownV2")
         parse_mode: 'Markdown',
         reply_markup: {
           inline_keyboard: [
-            [{ text: '✨ עיצוב טקסט', callback_data: 'train_topic_text-formatting' }],
-            [{ text: '📊 טבלאות', callback_data: 'train_topic_tables' }],
-            [{ text: '🔗 קישורים ותמונות', callback_data: 'train_topic_links-images' }],
-            [{ text: '📋 רשימות מתקדמות', callback_data: 'train_topic_advanced-lists' }],
-            [{ text: '🐛 איתור באגים', callback_data: 'train_topic_bug-detection' }],
-            [{ text: '📈 דיאגרמות Mermaid', callback_data: 'train_topic_mermaid' }]
+            [
+              { text: '✨ עיצוב טקסט', callback_data: 'train_topic_text-formatting' },
+              { text: '📊 טבלאות', callback_data: 'train_topic_tables' }
+            ],
+            [
+              { text: '🔗 קישורים ותמונות', callback_data: 'train_topic_links-images' },
+              { text: '📋 רשימות מתקדמות', callback_data: 'train_topic_advanced-lists' }
+            ],
+            [
+              { text: '💻 קוד וסינטקס', callback_data: 'train_topic_code-blocks' },
+              { text: '🛡️ תווים מיוחדים', callback_data: 'train_topic_escaping' }
+            ],
+            [
+              { text: '🗨️ ציטוטים והתראות', callback_data: 'train_topic_quotes-alerts' },
+              { text: '📐 HTML בתוך Markdown', callback_data: 'train_topic_html-markdown' }
+            ],
+            [
+              { text: '📈 דיאגרמות Mermaid', callback_data: 'train_topic_mermaid' },
+              { text: '🐛 איתור באגים', callback_data: 'train_topic_bug-detection' }
+            ]
           ]
         }
       }


### PR DESCRIPTION
Improve sandbox rendering for Mermaid, tables, and images, and add missing training topics to the focused training menu.

The sandbox now correctly identifies and renders Mermaid diagrams even when not explicitly wrapped in ````mermaid``` or when sent as plain text. It also unwraps tables and images from code blocks to ensure they render as rich HTML elements instead of pre-formatted text. The focused training menu now includes all previously added topics from issue #55.

---
<a href="https://cursor.com/background-agent?bcId=bc-1be115d4-2ced-418f-9505-f6b076e67b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1be115d4-2ced-418f-9505-f6b076e67b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

