### PR TITLE
Add /webapp command to link to Markdown Academy web app

### DIFF
--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -80,7 +80,8 @@ class CommandHandler {
       `/sandbox - פתח מעבדת תרגול (Markdown → תמונה)\n` +
       `/themes - בחר ערכת נושא לארגז החול\n` +
       `/templates - תבניות Markdown מוכנות לשימוש\n` +
-      `/cheatsheet - הצג מדריך מהיר\n`;
+      `/cheatsheet - הצג מדריך מהיר\n` +
+      `/webapp - פתח את אפליקציית הווב\n`;
 
     if (this.isAdmin(userId)) {
       helpText += `/didyouknow - כרטיסיות "הידעת?" קצרות\n`;
@@ -1375,6 +1376,23 @@ await update.message.reply_text(msg, parse_mode="MarkdownV2")
   // ========================================
   // /review_templates - Admin: Review pending template submissions
   // ========================================
+  // ========================================
+  // /webapp - Link to the web app
+  // ========================================
+  async handleWebapp(msg) {
+    const chatId = msg.chat.id;
+    const userId = msg.from.id;
+
+    this.db.updateLastActive(userId);
+
+    await this.bot.sendMessage(chatId,
+      `🌐 *Markdown Academy - Web App*\n\n` +
+      `ניתן לגשת לאפליקציית הווב שלנו בקישור הבא:\n\n` +
+      `👉 https://markdown-academy.onrender.com`,
+      { parse_mode: 'Markdown' }
+    );
+  }
+
   async handleReviewTemplates(msg) {
     const chatId = msg.chat.id;
     const userId = msg.from.id;

--- a/index.js
+++ b/index.js
@@ -315,6 +315,14 @@ if (bot && commandHandler && messageHandler) {
     }
   });
 
+  // Handle /webapp command (link to web app)
+  bot.onText(/\/webapp/, async (msg) => {
+    reportUserActivity(msg?.from?.id);
+    if (await maintenanceMiddleware(msg, () => true)) {
+      commandHandler.handleWebapp(msg);
+    }
+  });
+
   // Handle /review_templates command (admin only)
   bot.onText(/\/review_templates/, async (msg) => {
     reportUserActivity(msg?.from?.id);


### PR DESCRIPTION
הפקודה `/webapp` נוספה בהצלחה. הנה מה שנעשה:

1. **`handlers/commandHandler.js`** - נוסף מתודה `handleWebapp` שמחזירה הודעה עם הקישור `https://markdown-academy.onrender.com`
2. **`index.js`** - נרשם ה-listener עבור `/webapp` (באותו דפוס כמו שאר הפקודות)
3. **`handlers/commandHandler.js`** - הפקודה `/webapp` נוספה גם לטקסט העזרה (`/help`)

כשמשתמש ישלח `/webapp`, הבוט יחזיר הודעה עם הקישור לאפליקציית הווב.

## Summary
Added a new `/webapp` command that provides users with a direct link to the Markdown Academy web application hosted on Render.

## Key Changes
- **commandHandler.js**:
  - Added `/webapp` command to the help text displayed to all users
  - Implemented `handleWebapp()` method that sends a message with the web app URL (https://markdown-academy.onrender.com)
  - Method includes user activity tracking via `updateLastActive()`

- **index.js**:
  - Registered the `/webapp` command handler with bot text matching
  - Integrated with existing middleware (maintenance check and user activity reporting)

## Implementation Details
- The command follows the existing pattern used by other commands in the handler
- Uses Markdown formatting for the response message with an emoji indicator (🌐)
- Includes both English and Hebrew text to match the bot's bilingual interface
- Properly integrated with the maintenance middleware to respect system status
- User activity is tracked when the command is executed

https://claude.ai/code/session_018AxRPwGvW5dfz12HhP1Cro